### PR TITLE
add support for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,6 @@ objdiff.json
 /objdiff-cli.exe
 build.ninja
 .ninja_*
-/wibo
+/wibo-*
 ghidra/exports
 ghidra/*$py.class

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,6 +12,7 @@ Contents:
 1. Use one of these platforms:
     - Windows (recommended)
     - Linux
+    - macOS
 2. Install the following:
     - Python 3.11+ and pip
     - GCC 9+
@@ -33,7 +34,7 @@ Now you can run `ninja` to build a ROM for the chosen version.
 > Rerun `configure.py` often to ensure that all C/C++ code gets compiled.
 
 > [!NOTE]
-> For Linux users: Wibo is used by default. If you want to use Wine instead, run `configure.py` with `-w <path/to/wine>`.
+> For Linux & macOS users: Wibo is used by default. If you want to use Wine instead, run `configure.py` with `-w <path/to/wine>`.
 
 ### Matching the base ROM
 

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -11,14 +11,20 @@ from typing import Any
 import ninja_syntax
 from get_platform import Platform, get_platform
 
+platform = get_platform()
+if platform is None:
+    exit(1)
 
 # Game versions
 VERSIONS = [
     "YLZE01",
 ]
 DEFAULT_VERSION = VERSIONS.index("YLZE01")
-DEFAULT_WIBO_PATH = "./wibo"
 
+if platform.system == "macos":
+    DEFAULT_WIBO_PATH = "./wibo-macos"
+else:
+    DEFAULT_WIBO_PATH = f"./wibo-{platform.machine}"
 
 parser = argparse.ArgumentParser(description="Generates build.ninja")
 parser.add_argument('-w', type=str, default=DEFAULT_WIBO_PATH, dest="wine", required=False, help="Path to Wine/Wibo (linux only)")
@@ -31,7 +37,7 @@ args = parser.parse_args()
 
 # Config
 DSD_VERSION = 'v0.10.2'
-WIBO_VERSION = '0.6.16'
+WIBO_VERSION = '1.0.1'
 OBJDIFF_VERSION = 'v3.0.0-beta.6'
 MWCC_VERSION = "2.0/sp1p2"
 DECOMP_ME_COMPILER = "mwcc_30_126"
@@ -117,9 +123,6 @@ CC_INCLUDES = " ".join(f"-i {include}" for include in includes)
 
 
 # Platform info
-platform = get_platform()
-if platform is None:
-    exit(1)
 EXE = platform.exe
 WINE = args.wine if platform.system != "windows" else ""
 DSD = str(args.dsd or os.path.join('.', str(root_path / f"dsd{EXE}")))

--- a/tools/download_tool.py
+++ b/tools/download_tool.py
@@ -27,7 +27,9 @@ def mwccarm_url(tag: str) -> str:
     return 'http://decomp.aetias.com/files/mwccarm.zip'
 
 def wibo_url(tag: str) -> str:
-    return f'https://github.com/decompals/wibo/releases/download/{tag}/wibo'
+    if platform.system == "macos":
+        return f'https://github.com/decompals/wibo/releases/download/{tag}/wibo-macos'
+    return f'https://github.com/decompals/wibo/releases/download/{tag}/wibo-{platform.machine}'
 
 def objdiff_url(tag: str) -> str:
     return f'https://github.com/encounter/objdiff/releases/download/{tag}/objdiff-cli-{platform.system}-{platform.machine}{platform.exe}'

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -4,9 +4,9 @@ import platform
 class Platform:
     def __init__(self, *, system: str, machine: str, exe: str):
         self.system = system
-        '''Name of operating system: "windows" or "linux"'''
+        '''Name of operating system: "windows", "macos", or "linux"'''
         self.machine = machine
-        '''Name of machine architecture: "x86_64"'''
+        '''Name of machine architecture: "x86_64", or "arm64"'''
         self.exe = exe
         '''Executable file extension: ".exe" for Windows, "" otherwise'''
 
@@ -19,11 +19,14 @@ def get_platform() -> Platform | None:
         exe = ".exe"
     elif system == "Linux":
         system = "linux"
+    elif system == "Darwin":
+        system = "macos"
     else:
         print(f"Unknown system '{system}'")
         return None
     match platform.machine().lower():
         case "amd64" | "x86_64": machine = "x86_64"
+        case "aarch64" | "arm64": machine = "arm64"
         case machine:
             print(f"Unknown machine: {machine}")
             return None


### PR DESCRIPTION
Please note that this PR updates the version of wibo that is used. The name of the wibo binary has changed (from just `wibo` to `wibo-x86_64` or `wibo-arm64`).